### PR TITLE
improve findGitDir

### DIFF
--- a/git.go
+++ b/git.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"os/exec"
-	"path/filepath"
 )
 
 const maxGitRecursion = 32
@@ -16,17 +16,16 @@ func checkGitInPath() error {
 	return nil
 }
 
-func findGitDir(start string, count int) (string, error) {
-	if info, err := os.Stat(filepath.Join(start, ".git")); err == nil {
-		if info.IsDir() {
-			return start, nil
-		}
+func findGitDir() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	output, err := cmd.CombinedOutput()
+	
+	if err != nil {
+		return "", fmt.Errorf(string(output))
 	}
-	above := filepath.Dir(start)
-	if above == start || count >= maxGitRecursion {
-		return "", fmt.Errorf("not a git repository: .git directory not found")
-	}
-	return findGitDir(above, count+1)
+
+
+	return strings.TrimSpace(string(output)), nil
 }
 
 func commit(msg string, body bool, signOff bool) error {

--- a/main.go
+++ b/main.go
@@ -12,17 +12,12 @@ func main() {
 		fail("Error: %s", err)
 	}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		cwd = "."
-	}
-
-	dir, err := findGitDir(cwd, 0)
+	gitRoot, err := findGitDir()
 	if err != nil {
 		fail("Error: %s", err)
 	}
 
-	if err := os.Chdir(dir); err != nil {
+	if err := os.Chdir(gitRoot); err != nil {
 		fail("Error: could not change directory: %s", err)
 	}
 


### PR DESCRIPTION
Hi @liamg,

nice tool I love it. 

I believe using `git rev-parse show-toplevel` in order to find the git root directory is a more convenient approach

I could add some tests if you want to

What do you think? 