### PR TITLE
feat: support validating commit messages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.17'
+        go-version: '1.18'
 
     - name: Release
       uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.18.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You can call `comet` where you'd normally type `git commit`. All flags supported
 
 ## Installation
 
-Install with Go (1.17+):
+Install with Go (1.18+):
 
 ```console
 go install github.com/liamg/comet@latest
@@ -31,4 +31,17 @@ The content should be in the following format:
     { "title":  "bug", "description":  "introducing a bug"}
   ]
 }
+```
+
+## Verify commit messages
+`comet` can be used to verify commit messages via STDIN:
+```bash
+# valid commit
+echo "feat: support JSON" | comet; echo $?
+0
+
+# invalid
+echo "invalid commit message" | comet; echo $?
+Error: invalid commit message
+1
 ```

--- a/git.go
+++ b/git.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
-	"strings"
 	"os/exec"
+	"strings"
 )
 
 const maxGitRecursion = 32
@@ -19,11 +20,10 @@ func checkGitInPath() error {
 func findGitDir() (string, error) {
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
 	output, err := cmd.CombinedOutput()
-	
+
 	if err != nil {
 		return "", fmt.Errorf(string(output))
 	}
-
 
 	return strings.TrimSpace(string(output)), nil
 }
@@ -43,4 +43,24 @@ func commit(msg string, body bool, signOff bool) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+func verifyCommitMessage(msg string) bool {
+	prefixes, _, err := loadConfig()
+	if err != nil {
+		log.Fatalf("cannot load config: %v", err)
+	}
+
+	title, msg, ok := strings.Cut(msg, ":")
+	if !ok || msg == "" {
+		return false
+	}
+
+	for _, v := range prefixes {
+		if v.FilterValue() == title {
+			return true
+		}
+	}
+
+	return false
 }

--- a/git_test.go
+++ b/git_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestVerifyCommitMessage(t *testing.T) {
+	testCases := []struct {
+		name  string
+		msg   string
+		valid bool
+	}{
+		{
+			msg:   "feat: valid message",
+			valid: true,
+		},
+		{
+			msg:   "feat:",
+			valid: false,
+		},
+		{
+			msg:   "invalid",
+			valid: false,
+		},
+		{
+			msg:   "feat commit message",
+			valid: false,
+		},
+		{
+			msg:   "feat",
+			valid: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		res := verifyCommitMessage(tc.msg)
+
+		if tc.valid != res {
+			t.Fail()
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/liamg/comet
 
-go 1.17
+go 1.18
 
 require (
 	github.com/charmbracelet/bubbles v0.10.3


### PR DESCRIPTION
`comet` can be used to verify commit messages via STDIN:
```bash
# valid commit
echo "feat: support JSON" | comet; echo $?
0

# invalid
echo "invalid commit message" | comet; echo $?
Error: invalid commit message
1
```